### PR TITLE
모듈 번들러가 ES module을 잘 인식하도록 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.2.6",
   "description": "Functional Extensions for Javascript",
   "main": "index.js",
+  "module": "fx.js",
+  "sideEffects": false,
   "scripts": {
     "test": "mocha -R spec test/**/*.js"
   },


### PR DESCRIPTION
package.json에 "main" 필드가 index.js 파일로 지정 되어있고, index.js파일은 esm library를 이용하여 CommonJS module로 변환하고 있기 때문에 모듈 번들러가 ES module로 인식하지 못하는 것 같습니다.
예를 들어 아래 코드를 webpack으로 bundling하면 에러가 납니다.


```
import { log } from 'fxjs2';
log('hi~');
```

package.json의 module 필드에 ES module entry 경로를 잘 명시해서 bundler에 힌트를 주면 위의 코드가 잘bundling 됩니다 😃 

그리고 webpack4에서 위의 코드를 bundling 했을 때 tree-shaking이 잘 적용되지 않아 검색 해보니 해당 library package.json에 sideEffects 필드가 false여야 하네요. webpack이 사용되지 않은 코드를 제거했을 때 실제로 문제가 없을지 정확히 알기 힘들기 때문에 library 개발자에게 책임을 위임한 것 같습니다.

*참고*
- [Webpack에서 Tree Shaking 적용하기](https://medium.com/naver-fe-platform/webpack%EC%97%90%EC%84%9C-tree-shaking-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0-1748e0e0c365)
- [Webpack 4의 Tree Shaking에 대한 이해](https://huns.me/development/2265)