### PR TITLE
partition 빈 배열 추가

### DIFF
--- a/Strict/partition.js
+++ b/Strict/partition.js
@@ -6,5 +6,5 @@ import pipe1 from "./pipe1.js";
 export default curry(function partition(f, iter) {
   return go1(
     groupBy(pipe1(f, Boolean), iter),
-    group => [group['true'], group['false']]);
+    group => [group['true'] || [], group['false']] || []);
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -1195,6 +1195,10 @@ import * as C from "../Concurrency/index.js";
       expect(partition(a => a % 2, [1, 2, 3, 4])).to.eql([[1, 3], [2, 4]]);
     });
 
+    it("partition(a => a % 2, [2, 4])", function () {
+      expect(partition(a => a % 2, [2, 4])).to.eql([[], [2, 4]]);
+    });
+
     it("partition(a => Promise.resolve(a % 2), [1, 2, 3, 4])", async function () {
       expect(await partition(a => Promise.resolve(a % 2), [1, 2, 3, 4])).to.eql([[1, 3], [2, 4]]);
     });


### PR DESCRIPTION
partition 사용시에 참/거짓 값이 하나도 존재하지 않으면 빈 배열이 아니라 undefined 로 떨어지던데, 그것 보다는 빈배열로 나오는 것이 이후에 다루기에 더 용이할 것이라 생각하여 올려봅니다.